### PR TITLE
Fix: Resolve missing typeguard dependency by installing hvplot before…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,9 @@ conda create -n spotr -y python=3.7 numpy=1.20 numba
 conda activate spotr
 
 conda install -y pytorch=1.10.1 torchvision cudatoolkit=11.3 -c pytorch -c nvidia
-
+conda install -c pyviz hvplot
 pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.1+cu113.html
+pip install typing-extensions --upgrade
 pip install -r requirements.txt
 
 # install cpp extensions, the pointnet++ library


### PR DESCRIPTION
### Summary
This PR resolves a dependency conflict during installation where `generate-parameter-library-py` requires `typeguard`, which pip's resolver does not install automatically.

### Changes Made
- Added the command `conda install -c pyviz hvplot` to `install.sh` before installing `requirements.txt`.
- This resolves the following error:
  ```
  ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
  generate-parameter-library-py 0.3.8 requires typeguard, which is not installed.
  ```

### Testing
- Performed a fresh installation after the fix, and the installation completed without dependency errors.

### References
- Resolves issue #<issue-number> (if any).
